### PR TITLE
Added some more SQL,fixed comment errors

### DIFF
--- a/modules/syntax/pascal/pascal.h
+++ b/modules/syntax/pascal/pascal.h
@@ -23,14 +23,12 @@ char *PAS_keywords[] = {
 
 
 
-#define Pascal_syntax { \
+#define PAS_syntax { \
 	PAS_extensions, \
 	PAS_keywords, \
-	"(*", \
-	"*(", \
+    "#", \
 	"{", \
 	"}", \
-	"//", \
 	HL_HIGHLIGHT_NUMBERS | HL_HIGHLIGHT_STRINGS \
 }
 

--- a/modules/syntax/php/php.h
+++ b/modules/syntax/php/php.h
@@ -12,8 +12,6 @@ char *PHP_keywords[] = {
 		"protected^","static^",
         //conditionals
         "if~","else~","switch~","case~","try~","catch~","finally~","and","elseif~","default#","or","throw~",
-        //start
-        "<?php","?>",
         //conditionals
         "if~","else~","switch~","case~","try~","catch~","finally~",
         //return

--- a/modules/syntax/sql/sql.h
+++ b/modules/syntax/sql/sql.h
@@ -11,7 +11,6 @@ char *SQL_keywords[] = {
 #define SQL_syntax { \
 	SQL_extensions, \
 	SQL_keywords, \
-	"#", \
 	"-- ", \
 	"/*", \
 	"*/", \

--- a/modules/syntax/sql/sql.h
+++ b/modules/syntax/sql/sql.h
@@ -1,7 +1,7 @@
 #ifndef _SYNTAX_SQL_H
 #define _SYNTAX_SQL_H
 
-// C and C++
+// MySQL, just the beginning
 char *SQL_extensions[] = {".sql" ,NULL};
 char *SQL_keywords[] = {
 	"create","table","insert","from","values","select",

--- a/modules/syntax/syntax.h
+++ b/modules/syntax/syntax.h
@@ -37,7 +37,7 @@ struct editor_syntax highlight_db[] = {
     CCPP_syntax,
 	Python_syntax,
 	PHP_syntax,
-	Pascal_syntax,
+	PAS_syntax,
 	SQL_syntax
 };
 


### PR DESCRIPTION
By the way Python multi-line comments both start and end with '''.