### PR TITLE
Fix warning about syntax highlighter comments

### DIFF
--- a/modules/syntax/editor_syntax.h
+++ b/modules/syntax/editor_syntax.h
@@ -8,8 +8,8 @@ struct editor_syntax {
         char **filematch;
         char **keywords;
         char singleline_comment_start[3];
-        char multiline_comment_start[3];
-        char multiline_comment_end[3];
+        char multiline_comment_start[6];
+        char multiline_comment_end[6];
         int flags;
 };
 


### PR DESCRIPTION
HTML and Ruby multi line comments are too big for the char array
that is stored inside the editor_syntax structure. Something more
thoughtful could be done, but this is already a good way to get rid of
those warnings.

Signed-off-by: Rafael Campos Nunes <rafaelnunes@engineer.com>