### PR TITLE
Add 'copy-row' and 'delete-row' features

### DIFF
--- a/bric.h
+++ b/bric.h
@@ -181,6 +181,8 @@ int editor_open(char *filename); // load the specified program in the editor mem
 
 int editor_save(void); //save the current file on the disk
 
+int editor_copy_row();
+
 void editor_yank_row();
 
 void editor_paste_row();


### PR DESCRIPTION
Changed editor_yank_row() function to editor_copy_row() by removing the editor_delete_row() line.
Added another editor_yank_row() function to yank rows which uses editor_copy_row() function and then deletes the row, if copying is successful.
In the key processing function add 'cr' case, which copies the row and 'dr' case, which deletes the row.
So, now we have 4 functions 'cr', 'yr', 'dr' and 'pr' functions to copy, yank, delete and paste row respectively.

P.S. In the meanwhile also indented some unindented code.