### PR TITLE
vi style keybindings for end-of-line and beginning-of-line

### DIFF
--- a/bric.c
+++ b/bric.c
@@ -1759,6 +1759,12 @@ void editor_process_key_press(int fd)
                 	case 'g':
                     		editor_goto(1);
                     		break;
+			case '$':
+				editor_move_cursor(HOME_KEY);
+				break;
+			case '0':
+				editor_move_cursor(END_KEY);
+				break;
 			case 'a':
 				editor_move_cursor(ARROW_RIGHT);
 				Editor.mode = INSERT_MODE;

--- a/bric.c
+++ b/bric.c
@@ -1760,10 +1760,10 @@ void editor_process_key_press(int fd)
                     		editor_goto(1);
                     		break;
 			case '$':
-				editor_move_cursor(HOME_KEY);
+				editor_move_cursor(END_KEY);
 				break;
 			case '0':
-				editor_move_cursor(END_KEY);
+				editor_move_cursor(HOME_KEY);
 				break;
 			case 'a':
 				editor_move_cursor(ARROW_RIGHT);

--- a/modules/syntax/brain/brain.h
+++ b/modules/syntax/brain/brain.h
@@ -14,6 +14,7 @@ char *brain_keywords[] = {
         brain_keywords,      \
         "",                  \
         "",                  \
+	"",                  \
         HL_HIGHLIGHT_STRINGS \
 }
 


### PR DESCRIPTION
I know home and end work here but no harm in having vi style '$' and '0'. Also fixed a compile error I was getting with the new brain syntax header.