### PR TITLE
Fixed END_KEY code

### DIFF
--- a/bric.c
+++ b/bric.c
@@ -1404,10 +1404,10 @@ void editor_move_cursor(int key)
                 case END_KEY:
                         if(row->size>Editor.screen_columns-1)
                         {
-                                Editor.cursor_x=Editor.screen_columns-1;
-                                Editor.column_offset=row->size-(Editor.screen_columns+1)+1;
+                                Editor.cursor_x=Editor.screen_columns;
+                                Editor.column_offset=row->size-Editor.screen_columns+1;
                         } else {
-                                Editor.cursor_x=row->size-1;
+                                Editor.cursor_x=row->size;
                         }
                         break;
                 case PAGE_UP:


### PR DESCRIPTION
When END_KEY is pressed, the cursor now goes to the very end of the line instead of one character before the end.