### PR TITLE
Fixed missing multiline_comment_end field

### DIFF
--- a/modules/syntax/brain/brain.h
+++ b/modules/syntax/brain/brain.h
@@ -14,6 +14,7 @@ char *brain_keywords[] = {
         brain_keywords,      \
         "",                  \
         "",                  \
+        "",                  \
         HL_HIGHLIGHT_STRINGS \
 }
 


### PR DESCRIPTION
Before this patch, I got the compiler warning:
modules/syntax/syntax.h:59:3: warning: missing initializer for field ‘flags’ of ‘struct editor_syntax’ [-Wmissing-field-initializers]
This is because the multiline_comment_end field was missing.