### PR TITLE
Add tags based movement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all:
 
-	$(CC) -g -o bric bric.c -Wall -W -pedantic -std=gnu99 -lm
+	$(CC) -g -o bric bric.c tagstack.c -Wall -W -pedantic -std=gnu99 -lm
 
 install: all
 	cp bric /usr/local/bin/bric

--- a/bric.c
+++ b/bric.c
@@ -756,9 +756,6 @@ int editor_open(char *filename)
 {
         FILE *fp;
         Editor.dirty = 0;
-        free(Editor.filename);
-        Editor.filename = strdup(filename);
-
         fp = fopen(filename, "r");
         if(!fp) {
                 if(errno != ENOENT) {
@@ -1048,7 +1045,7 @@ void editor_refresh_screen(void)
         ab_append(&ab, "\x1b[0K", 4);
         ab_append(&ab, "\x1b[7m", 4);
         char status[80], rstatus[80];
-        int len = snprintf(status, sizeof(status), "%.20s =- %d lines %s", Editor.filename, Editor.num_of_rows, Editor.dirty ? "(modified)" : "");
+        int len = snprintf(status, sizeof(status), "%.50s =- %d lines %s", Editor.filename, Editor.num_of_rows, Editor.dirty ? "(modified)" : "");
         int rlen = snprintf(rstatus, sizeof(rstatus), "%d/%d", Editor.row_offset+Editor.cursor_y+1, Editor.num_of_rows);
         if(len > Editor.screen_columns) len = Editor.screen_columns;
         ab_append(&ab, status, len);
@@ -1530,6 +1527,147 @@ void editor_check_quit(int fd)
         }
 }
 
+// TAG MOVEMENT FUNCTIONS
+
+// Function to differentiate identifier names with language syntax
+int char_check(char c) {
+	if(c == ' ' || c == '\n' || c == '\t' || c == '(' || c == ')' || c == '{' || c == '}')
+		return 0;
+	if(c == '&' || c == '|' || c == '+' || c == '-' || c == '*' || c == '\\' || c == '/' )
+		return 0;
+	if(c == '^' || c == '%' || c == '=' || c == '[' || c == ']' || c == ';' || c == '>' || c == '<')
+		return 0;
+	if(c == '?' || c == ':' || c == '\'' || c == '\"' || c == '.' || c == ',' || c == '!')
+		return 0;
+	return 1;
+}
+
+// Function to get the key word (identifier) on which the cursor is positioned
+char* get_key(void) {
+	int i = 0;
+	int filerow = Editor.row_offset + Editor.cursor_y;
+	int filecol = Editor.column_offset + Editor.cursor_x;
+	if(!char_check(Editor.row[filerow].chars[filecol]))
+		return "";
+	while(filecol != -1 && char_check(Editor.row[filerow].chars[filecol]))
+		filecol--;
+	filecol++;
+	char *key = (char*)malloc(128 * sizeof(char));
+	while(char_check(Editor.row[filerow].chars[filecol])) {
+		key[i] = Editor.row[filerow].chars[filecol];
+		i++; 
+		filecol++;
+	}
+	key[i] = '\0';
+	return key;
+}
+
+// Function to parse the tags file ex command and search for the required line in the file
+int tagsearch(char *tosearch) {
+	int dest_index = 0, source_index = 2, i = 0;
+	char *parsedsearch = (char*)malloc(strlen(tosearch) * sizeof(char));
+	while(tosearch[source_index] != '$') {
+		if(tosearch[source_index] == '\\') {
+			source_index++;
+			continue;
+		}
+		parsedsearch[dest_index] = tosearch[source_index];
+		source_index++;
+		dest_index++;
+	}
+	parsedsearch[dest_index] = '\0';
+	for(i = 0; i < Editor.num_of_rows; i++) {
+		if(strstr(Editor.row[i].chars, parsedsearch) != NULL)
+			return i + 1;
+	}
+	return 0;
+}
+
+// Main function to handle tag movements
+int handle_tag_movement(int where) {
+	int linenumber = 0, i = 0;
+	char *key = get_key();
+	char tag_line[256], *tagname, *filename, *tosearch, *orig_filename;
+	FILE *fp;
+	int cursor_pos = Editor.cursor_y, cursor_offset = Editor.row_offset;
+	tagdata tag_data;
+	orig_filename = strdup(Editor.filename);
+	if(where == MOVE_BACK) {
+		if(isempty(&tag_stack)) {
+			editor_set_status_message("at bottom of tag stack");
+			return 1;
+		}
+		tag_data = pop(&tag_stack);
+		linenumber = tag_data.linenumber;
+		filename = strdup(tag_data.filename);
+		if(strcmp(filename, Editor.filename)) {
+                        if(Editor.dirty) {
+                                editor_set_status_message("Unsaved changes. Can't proceed");
+                                return 0;
+                        }
+                        editor_start(filename);
+                }
+		editor_goto(linenumber);
+		/*Position the page so that the cursor remains in the same line*/
+                for(i = 0; i < cursor_pos && Editor.cursor_y < Editor.num_of_rows - 1; i++)
+			editor_move_cursor(ARROW_DOWN);
+                for(; i > 0; i--)
+			editor_move_cursor(ARROW_UP);
+                for(i = 0; i < cursor_pos && Editor.row_offset + Editor.cursor_y > 0; i++)
+			editor_move_cursor(ARROW_UP);
+                for(; i > 0; i--)
+			editor_move_cursor(ARROW_DOWN);
+                return 1;		
+	}
+	if(key[0] == '\0') {
+		editor_set_status_message("No identifier under cursor");
+		return 0;
+	}
+	fp = fopen("tags", "r");
+	if(!fp) {
+		editor_set_status_message("tag not found: %s", key);
+		free(key);
+		return 0;
+	}
+	while(fgets(tag_line, 256, fp) != NULL) {
+		tagname = strtok(tag_line, "\t");
+		if(strcmp(tagname, key))
+			continue;
+		filename = strtok(NULL, "\t");
+		tosearch = strtok(NULL, "\t");
+		if(strcmp(filename, Editor.filename)) {
+			if(Editor.dirty) {
+				editor_set_status_message("Unsaved changes. Can't proceed");
+				return 0;				
+			}
+			editor_start(filename);
+		}
+		if(tosearch[0] == '/') {
+			linenumber = tagsearch(tosearch);
+		}
+		else {
+			sscanf(tosearch, "%d", &linenumber);
+		}
+		tag_data.linenumber = cursor_offset + cursor_pos + 1;
+		strcpy(tag_data.filename, orig_filename);
+		push(&tag_stack, tag_data);
+		editor_goto(linenumber);
+		/*Position the page so that the cursor remains in the same line*/
+                for(i = 0; i < cursor_pos && Editor.cursor_y < Editor.num_of_rows - 1; i++)
+			editor_move_cursor(ARROW_DOWN);
+                for(; i > 0; i--)
+			editor_move_cursor(ARROW_UP);
+                for(i = 0; i < cursor_pos && Editor.row_offset + Editor.cursor_y > 0; i++)
+			editor_move_cursor(ARROW_UP);
+                for(; i > 0; i--)
+			editor_move_cursor(ARROW_DOWN);
+		return 1;
+	}
+	editor_set_status_message("tag not found: %s", key);
+	free(key);
+	return 0;
+}
+
 void editor_parse_command(int fd, char *query)
 {
         if (numbers_only(query)) {
@@ -1607,6 +1745,7 @@ void editor_process_key_press(int fd)
         static int quit_times = BRIC_QUIT_TIMES;
         int c = editor_read_key(fd);
         int filerow = Editor.row_offset+Editor.cursor_y;
+	int filecol = Editor.column_offset+Editor.cursor_x;
         switch(Editor.mode) {
         case INSERT_MODE:
                 switch(c) {
@@ -1685,7 +1824,8 @@ void editor_process_key_press(int fd)
                         case ESC:
                                 Editor.mode = NORMAL_MODE;
                                 editor_set_status_message("Normal mode.");
-                                editor_move_cursor(ARROW_LEFT);
+				if(filecol != 0)
+                                	editor_move_cursor(ARROW_LEFT);
                                 break;
                         case HOME_KEY:
                                 editor_move_cursor(HOME_KEY);
@@ -1793,7 +1933,12 @@ void editor_process_key_press(int fd)
                         case PAGE_DOWN:
                                 editor_move_cursor(PAGE_DOWN);
                                 break;
-
+			case CTRL_M:
+				handle_tag_movement(MOVE_AHEAD);
+				break;
+			case CTRL_N:
+				handle_tag_movement(MOVE_BACK);
+				break;
                 }
                 break;
             case SELECTION_MODE:
@@ -1822,8 +1967,6 @@ void editor_process_key_press(int fd)
         Editor.prev_char = c;
         quit_times = BRIC_QUIT_TIMES;
 }
-
-
 
 int editor_file_was_modified(void)
 {
@@ -1981,9 +2124,22 @@ void close_editor(void)
     free(Editor.clipboard);
 }
 
+// Given a filename, start editor with that file opened
+void editor_start(char *filename) {
+	free(Editor.filename);
+        init_editor();
+        Editor.filename = strdup(filename);
+        load_config_file();
+        editor_select_syntax_highlight(filename);
+        editor_open(filename);
+        enable_raw_mode(STDIN_FILENO);
+        editor_set_status_message(help_message);
+}
+
 int main(int argc, char **argv)
 {
         int file_arg = -1;
+	init(&tag_stack);
         for (int i = 1; i < argc; i++)
         {
             if (argv[i][0] != '-')
@@ -1995,8 +2151,6 @@ int main(int argc, char **argv)
                 fprintf(stderr, "Usage: bric <filename>\n");
                 exit(1);
         }
-        init_editor();
-        load_config_file();
         for (int i = 1; i < argc; i++)
         {
             if (argv[i][0] == '-')
@@ -2004,10 +2158,7 @@ int main(int argc, char **argv)
                 parse_argument(argv[i]);
             }
         }
-        editor_select_syntax_highlight(argv[file_arg]);
-        editor_open(argv[file_arg]);
-        enable_raw_mode(STDIN_FILENO);
-        editor_set_status_message(help_message);
+	editor_start(argv[file_arg]);
         while(1) {
                 editor_refresh_screen();
                 editor_process_key_press(STDIN_FILENO);

--- a/bric.h
+++ b/bric.h
@@ -21,6 +21,7 @@
 #include <math.h>
 
 #include "modules/syntax/syntax.h"
+#include "modules/tag/tagfuncs.h"
 
 #define INSERT_MODE 0
 #define SELECTION_MODE 1
@@ -90,31 +91,33 @@ enum KEY_ACTION {
 	KEY_NULL = 0,
 	CTRL_G = CTRL_KEY('g'),
 	CTRL_R = CTRL_KEY('r'),
-  CTRL_Y = CTRL_KEY('y'),
-  CTRL_P = CTRL_KEY('p'),
-    CTRL_A = 1,
+        CTRL_Y = CTRL_KEY('y'),
+        CTRL_P = CTRL_KEY('p'),
+        CTRL_M = CTRL_KEY('m'),
+        CTRL_N = CTRL_KEY('n'),
+        CTRL_A = 1,
 	CTRL_C = 3,
 	CTRL_D = 4,
 	CTRL_F = 6,
-    CTRL_H = 8,
-    TAB = 9,
+        CTRL_H = 8,
+        TAB = 9,
 	CTRL_L = 12,
-    ENTER = 13,
-    CTRL_Q = 17,
-    CTRL_S = 19,
-    CTRL_U = 21,
-    CTRL_V = 22,
-    ESC = 27,
-    BACKSPACE = 127,
-    ARROW_LEFT = 1000,
-    ARROW_RIGHT,
-    ARROW_UP,
-    ARROW_DOWN,
-    DEL_KEY,
-    HOME_KEY,
-    END_KEY,
-    PAGE_UP,
-    PAGE_DOWN
+        ENTER = 13,
+        CTRL_Q = 17,
+        CTRL_S = 19,
+        CTRL_U = 21,
+        CTRL_V = 22,
+        ESC = 27,
+        BACKSPACE = 127,
+        ARROW_LEFT = 1000,
+        ARROW_RIGHT,
+        ARROW_UP,
+        ARROW_DOWN,
+        DEL_KEY,
+        HOME_KEY,
+        END_KEY,
+        PAGE_UP,
+        PAGE_DOWN
 };
 
 
@@ -238,6 +241,6 @@ int editor_file_was_modified(void);
 
 void init_editor(void);
 
-
+void editor_start(char *filename);
 
 #endif

--- a/modules/tag/documentation
+++ b/modules/tag/documentation
@@ -1,0 +1,28 @@
+TAGS FUNCTIONALITY USAGE DOCUMENTATION v0.0.1
+
+Ctags is a UNIX tool, that along with a text editor which can use it, makes it easy to navigate large source code projects.
+It provides features such as the ability to jump from the current source file to definitions of functions and structures in other files.  
+Ctags also supports many languages besides C.
+
+Ctags is first run on its own to generate a "tags" file, then it is invoked from within the editor.
+
+First of all cd into your project source code directory.
+
+Run the command :  
+	ctags -R *
+
+This should generate the "tags" file.
+
+Open the source code file and place cursor over the function, structure, structure member, class member or macro whose definition you want to navigate to.
+
+CTRL_M : Navigates you to the definition of the identifier under the cursor.
+
+CTRL_N : Brings you back.
+
+You can use CTRL_M multiple times, in nested way, for functions using other functions and then use CTRL_N equal number of times, to come back.
+
+This functionality heavily relies on the "tags" file which in turn depends on the UNIX tool "ctags".
+Reading manual page of ctags (run 'man ctags') will help user understanding this in more depth. 
+
+-Original writer - Yash Jakhotiya <mailsforyashj@gmail.com>
+-Date : 31st October 2017

--- a/modules/tag/tagfuncs.h
+++ b/modules/tag/tagfuncs.h
@@ -1,0 +1,13 @@
+//Header file for tag movement function prototypes
+
+#include "tagstack.h"
+
+#define MOVE_AHEAD 101
+#define MOVE_BACK 102
+
+tagstack tag_stack;
+
+int handle_tag_movement(int where);
+char* get_key(void);
+int char_check(char c);
+int tagsearch(char *tosearch);

--- a/modules/tag/tagstack.h
+++ b/modules/tag/tagstack.h
@@ -1,0 +1,18 @@
+//Header file for tag stack
+
+typedef struct tagdata {
+	char tagname[64];
+	int linenumber;
+	char filename[64];
+}tagdata;
+
+typedef struct tagstack{
+	tagdata data;
+	struct tagstack *p;
+}tagstack;
+
+int isempty(tagstack *s);
+void init(tagstack *s);
+void push(tagstack *s, tagdata element);
+tagdata pop(tagstack *s);
+

--- a/tagstack.c
+++ b/tagstack.c
@@ -1,0 +1,40 @@
+//Stack implementation for tag-based movement
+
+#include<stdlib.h>
+#include<string.h>
+#include<stdio.h>
+#include "modules/tag/tagstack.h"
+int isempty(tagstack *s) {
+	return s->p == NULL;
+}
+void init(tagstack *s) {
+	s->p = NULL;
+}
+void push(tagstack *s, tagdata element) {
+	tagstack *foo;
+	foo = s;
+	while(foo->p != NULL) {
+		foo = foo->p;
+	}
+	foo->p = (tagstack*)malloc(sizeof(tagstack));
+	strcpy(foo->p->data.tagname, element.tagname);
+	foo->p->data.linenumber = element.linenumber;
+	strcpy(foo->p->data.filename, element.filename);
+	foo->p->p = NULL;	
+}
+tagdata pop(tagstack *s) {
+	tagstack *foo, *curr;
+	tagdata element;
+	foo = s;
+	while(foo->p != NULL) {
+		curr = foo;
+		foo = foo->p;
+	}
+	strcpy(element.tagname, foo->data.tagname);
+	element.linenumber = foo->data.linenumber;
+	strcpy(element.filename, foo->data.filename);
+	free(curr->p);
+	curr->p = NULL;
+	return element;
+}
+


### PR DESCRIPTION
Added code for tags based movement. CTRL_M moves ahead (e.g. to a function definition, like CTRL_] in vim), CTRL_N moves back (like CTRL_t in vim). The movement can be nested. Used a stack to implement that. 

A tags file has to be present for the functionality to work. `cd` to your code directory and run `ctags -R *`.

There are various nitty-gritty's in implementing tags-based movement, like handling situations like trying to move back when the tag stack is empty or trying to go to a function defined in another file without saving the current one. I have tried including all of them. If you want to know why I wrote a specific line of code, feel free to shoot me an email.