### PR TITLE
fix unused parameter compiler error in sigwinch_handler

### DIFF
--- a/bric.c
+++ b/bric.c
@@ -5,7 +5,7 @@ static struct termios orig_termios; // so we can restore original at exit
 static int line_number_length = 3;
 const char* line_number_format[] = {"%1d", "%2d", "%3d", "%4d", "%5d"};
 
-void sigwinch_handler(int arg)
+void sigwinch_handler()
 {
 	int old_columns = Editor.screen_columns;
 	if (get_window_size(STDIN_FILENO, STDOUT_FILENO, &Editor.screen_rows, &Editor.screen_columns) == -1) {


### PR DESCRIPTION
I was getting an unsused parameter compile-time error in the sigwinch_handler. Removing the parameter fixes the error, and the feature works as expected.