### PR TITLE
Added bash & Makefile basic syntax

### DIFF
--- a/modules/syntax/bash/bash.h
+++ b/modules/syntax/bash/bash.h
@@ -1,0 +1,34 @@
+#ifndef _SYNTAX_BASH_H
+#define _SYNTAX_BASH_H
+
+// BASH
+char *BASH_extensions[] = {".sh", NULL};
+char *BASH_keywords[] = {
+
+	// Keyword: Misc	
+	"function", "select", "read", "echo", "break", 
+	"export", "let", "clear", "exit",
+	"!", ";;", "|", ">", ">>", "<<", "<", "&",
+
+	// Keyword: Conditionals
+	"if~", "elif~", "else~", "fi~",  "case~", "esac~", "then~",
+
+	// Keyword: Return
+	"return#",
+
+	// Keyword: Loops
+	"for@", "while@", "until@", "in@", "do@", "done@",
+
+	NULL
+};
+
+#define BASH_syntax {	\
+	BASH_extensions,	\
+	BASH_keywords, 		\
+	"#",				\
+	"#", 				\
+	"#", 				\
+	HL_HIGHLIGHT_NUMBERS | HL_HIGHLIGHT_STRINGS \
+}
+
+#endif

--- a/modules/syntax/brain/brain.h
+++ b/modules/syntax/brain/brain.h
@@ -1,17 +1,17 @@
 #ifndef _SYNTAX_BRAIN_H
 #define _SYNTAX_BRAIN_H
 
-char *brain_extensions[] = {".brain", ".b", NULL};
-char *brain_keywords[] = {
+char *BRAIN_extensions[] = {".brain", ".b", NULL};
+char *BRAIN_keywords[] = {
     "+", "-", "#", ".", ",", ">", "<", "*", "[", "]", "{", "}",
     "$", "/", "%", "!", "?", ":", ";", "^", NULL
 };
 
-// Anything else than those keywords are considered comments in Brain.
+// Anything else than those keywords are considered comments in BRAIN.
 
-#define brain_syntax {       \
-        brain_extensions,    \
-        brain_keywords,      \
+#define BRAIN_syntax {       \
+        BRAIN_extensions,    \
+        BRAIN_keywords,      \
         "",                  \
         "",                  \
 	"",                  \

--- a/modules/syntax/ccpp/ccpp.h
+++ b/modules/syntax/ccpp/ccpp.h
@@ -2,7 +2,7 @@
 #define _SYNTAX_CCPP_H
 
 // C and C++
-char *CCPP_extensions[] = {".c", ".cpp", ".h" ,NULL};
+char *CCPP_extensions[] = {".c", ".cpp", ".h" , ".hpp", NULL};
 char *CCPP_keywords[] = {
 	//types and misc
 	"char", "bool", "short", "int", "__int8", "__int16", "__int32", "__int64",

--- a/modules/syntax/makefile/makefile.h
+++ b/modules/syntax/makefile/makefile.h
@@ -1,0 +1,29 @@
+#ifndef _SYNTAX_MAKEFILE_H
+#define _SYNTAX_MAKEFILE_H
+
+// MAKEFILE
+char *MAKEFILE_extensions[] = {"Makefile", NULL};
+char *MAKEFILE_keywords[] = {
+
+	// Keyword: Misc
+	"$(CC)@", "CC@", "$(CFLAGS)@", "CFLAGS@", "$(MAKE)@",
+
+	// Keyword: Stuff
+	".PHONY:", "export",
+
+	// Keyword: Basic Rules
+	"all:~", "clean:~", "install:~",
+
+	NULL
+};
+
+#define MAKEFILE_syntax { \
+	MAKEFILE_extensions, \
+	MAKEFILE_keywords, \
+	"#", \
+	"#", \
+	"#", \
+	HL_HIGHLIGHT_NUMBERS | HL_HIGHLIGHT_STRINGS \
+}
+
+#endif

--- a/modules/syntax/rust/rust.h
+++ b/modules/syntax/rust/rust.h
@@ -1,9 +1,9 @@
 #ifndef _SYNTAX_RUST_H
 #define _SYNTAX_RUST_H
 
-//rust
-char *rust_extensions[] = {".rs", ".rlib", NULL};
-char *rust_keywords[] = {
+//RUST
+char *RUST_extensions[] = {".rs", ".rlib", NULL};
+char *RUST_keywords[] = {
   // types and misc
   "str", "bool", "char", "i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64", "isize", "usize", "f32", "f64", "struct", "enum", "true", "false",
   // cargo stuff
@@ -24,9 +24,9 @@ char *rust_keywords[] = {
   NULL
 };
 
-#define rust_syntax { \
-	rust_extensions, \
-	rust_keywords, \
+#define RUST_syntax { \
+	RUST_extensions, \
+	RUST_keywords, \
 	"//", \
 	"/*", \
 	"*/", \

--- a/modules/syntax/syntax.h
+++ b/modules/syntax/syntax.h
@@ -16,6 +16,8 @@
 #include "html/html.h"
 #include "d/d.h"
 #include "brain/brain.h"
+#include "bash/bash.h"
+#include "makefile/makefile.h"
 
 // Syntax highlighting macros
 #define HL_NORMAL 0
@@ -56,7 +58,9 @@ struct editor_syntax highlight_db[] = {
   rust_syntax,
   HTML_syntax,
   D_syntax,
-  brain_syntax
+  brain_syntax,
+  BASH_syntax,
+  MAKEFILE_syntax
 };
 
 #define HIGHLIGHT_DB_ENTRIES (sizeof(highlight_db)/sizeof(highlight_db[0]))

--- a/modules/syntax/syntax.h
+++ b/modules/syntax/syntax.h
@@ -55,10 +55,10 @@ struct editor_syntax highlight_db[] = {
   JAVASCRIPT_syntax,
   GO_syntax,
   RUBY_syntax,
-  rust_syntax,
+  RUST_syntax,
   HTML_syntax,
   D_syntax,
-  brain_syntax,
+  BRAIN_syntax,
   BASH_syntax,
   MAKEFILE_syntax
 };


### PR DESCRIPTION
I've added some files to handle the syntax for the `Makefile` and `.sh` files.

Also I've made a change to support C++ Headers `.hpp` extension.

And finally I've correct some lowercase variable names there was related with rust and brain syntax. In order to have a standard style guide for our code.