### PR TITLE
Fixed a segfault bug in get_key

### DIFF
--- a/src/bric.c
+++ b/src/bric.c
@@ -1701,7 +1701,8 @@ char* get_key(void) {
 	int i = 0;
 	int filerow = Editor.row_offset + Editor.cursor_y;
 	int filecol = Editor.column_offset + Editor.cursor_x;
-	if(!char_check(find_row(filerow)->chars[filecol]))
+	editing_row *row = find_row(filerow);
+	if (row == NULL || !char_check(row->chars[filecol]))
 		return "";
 	while(filecol != -1 && char_check(find_row(filerow)->chars[filecol]))
 		filecol--;


### PR DESCRIPTION
When on the first line, find_row(filerow) == NULL. I added a check for this case to prevent a segmentation fault.