### PR TITLE
add autoconf and automake file (for issue #73)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,24 @@
+EXTRA_DIST=         \
+	README.md         	\
+	LICENSE
+
+bin_PROGRAMS=bric
+AM_CFLAGS= -std=gnu99 -Wall -g -W -pedantic -lm
+
+bric_SOURCES = 	bric.c					\
+								src/locking.c 	\
+								tagstack.c
+
+# bric_LDFLAGS = 
+
+ACLOCAL_AMFLAGS = -I m4
+
+PACKAGE = @PACKAGE@
+VERSION = @VERSION@
+
+ACLOCAL = true
+AUTOCONF = true
+AUTOHEADER = true
+AUTOMAKE = true
+
+distdir = $(PACKAGE)-$(VERSION)

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,11 @@
+AC_INIT(bric, git, [noone@localhost])
+AM_INIT_AUTOMAKE([subdir-objects])
+AC_PREREQ(2.69)
+AC_CONFIG_HEADERS([config.h:config.in])
+AC_PROG_CC([cc])
+AC_CONFIG_MACRO_DIRS([m4])
+AC_PROG_LIBTOOL
+AC_PROG_INSTALL
+AM_PROG_CC_C_O
+
+AC_OUTPUT(Makefile)


### PR DESCRIPTION
This is to help with #73 

Assuming you have the autotools packages installed, to use these two
files, just run

    aclocal -I m4
    autoreconf -ivf
    automake

After that, to build, users can use

    ./configure
    make
    make install