### PR TITLE
fix memory leaks from locking.c and correct strlen computation in bric.c

### DIFF
--- a/bric.c
+++ b/bric.c
@@ -2303,7 +2303,10 @@ void close_editor(void)
 void editor_start(char *filename) {
         free(Editor.filename);
         init_editor();
-        Editor.filename = (char*)malloc(sizeof(char) * strlen(filename));
+        /*  add +1 here because strlen computes the length of the string up
+        /   to, but not including the terminating null character.
+         */
+        Editor.filename = (char*)malloc(sizeof(char) * strlen(filename)+1);
 	strcpy(Editor.filename, filename);
         load_config_file();
         editor_select_syntax_highlight(filename);

--- a/src/locking.c
+++ b/src/locking.c
@@ -69,6 +69,7 @@ void lock_file(struct __current_file current_file)
         fclose(locker_file);
     }
 
+    free(locker);
     return;
 }
 
@@ -93,6 +94,7 @@ void unlock_file(struct __current_file current_file)
         remove(locker);
     }
 
+    free(locker);
     return;
 }
 
@@ -115,8 +117,9 @@ int is_file_locked(struct __current_file current_file)
     if (locker_file)
     {
         fclose(locker_file);
+        free(locker);
         return 1;
     }
-
+    free(locker);
     return 0;
 }


### PR DESCRIPTION
In locking.c several functions call get_locker_name are but never free'd.
In bric.c the filename does not account for the null terminator.

valgrind now reports
==28910== HEAP SUMMARY:
==28910==     in use at exit: 72 bytes in 5 blocks
==28910==   total heap usage: 1,206 allocs, 1,201 frees, 922,261 bytes allocated
==28910==
==28910== LEAK SUMMARY:
==28910==    definitely lost: 0 bytes in 0 blocks
==28910==    indirectly lost: 0 bytes in 0 blocks
==28910==      possibly lost: 0 bytes in 0 blocks

whereas, previously we see (invalid write is from the incorrect Editor.filename strlen call)
==2348== Invalid write of size 4
==2348==    at 0x3F89934B47: ??? (in /lib64/libc-2.12.so)
==2348==    by 0x406FFA: editor_start (bric.c:2307)
==2348==    by 0x4071BA: main (bric.c:2348)
==2348==  Address 0x4c3e9c2 is 2 bytes inside a block of size 5 alloc'd
==2348==    at 0x4A0676F: malloc (vg_replace_malloc.c:263)
==2348==    by 0x406FDD: editor_start (bric.c:2306)
==2348==    by 0x4071BA: main (bric.c:2348)

==2348== HEAP SUMMARY:
==2348==     in use at exit: 2,119 bytes in 9 blocks
==2348==   total heap usage: 1,206 allocs, 1,197 frees, 922,260 bytes allocated
==2348==
==2348== 512 bytes in 1 blocks are definitely lost in loss record 6 of 9
==2348==    at 0x4A0676F: malloc (vg_replace_malloc.c:263)
==2348==    by 0x407431: get_locker_name (in /usr/people/bryce-e/dev/bric/bric)
==2348==    by 0x40759B: is_file_locked (in /usr/people/bryce-e/dev/bric/bric)
==2348==    by 0x407109: main (bric.c:2335)
==2348==
==2348== 512 bytes in 1 blocks are definitely lost in loss record 7 of 9
==2348==    at 0x4A0676F: malloc (vg_replace_malloc.c:263)
==2348==    by 0x407431: get_locker_name (in /usr/people/bryce-e/dev/bric/bric)
==2348==    by 0x4074BB: lock_file (in /usr/people/bryce-e/dev/bric/bric)
==2348==    by 0x40712B: main (bric.c:2336)
==2348==
==2348== 512 bytes in 1 blocks are definitely lost in loss record 8 of 9
==2348==    at 0x4A0676F: malloc (vg_replace_malloc.c:263)
==2348==    by 0x407431: get_locker_name (in /usr/people/bryce-e/dev/bric/bric)
==2348==    by 0x40759B: is_file_locked (in /usr/people/bryce-e/dev/bric/bric)
==2348==    by 0x40562A: editor_harsh_quit (bric.c:1647)
==2348==    by 0x406021: editor_parse_command (bric.c:1846)
==2348==    by 0x4061C9: enter_command (bric.c:1884)
==2348==    by 0x406785: editor_process_key_press (bric.c:2041)
==2348==    by 0x4071C9: main (bric.c:2351)
==2348==
==2348== 512 bytes in 1 blocks are definitely lost in loss record 9 of 9
==2348==    at 0x4A0676F: malloc (vg_replace_malloc.c:263)
==2348==    by 0x407431: get_locker_name (in /usr/people/bryce-e/dev/bric/bric)
==2348==    by 0x40752A: unlock_file (in /usr/people/bryce-e/dev/bric/bric)
==2348==    by 0x40564C: editor_harsh_quit (bric.c:1648)
==2348==    by 0x406021: editor_parse_command (bric.c:1846)
==2348==    by 0x4061C9: enter_command (bric.c:1884)
==2348==    by 0x406785: editor_process_key_press (bric.c:2041)
==2348==    by 0x4071C9: main (bric.c:2351)
==2348==
==2348== LEAK SUMMARY:
==2348==    definitely lost: 2,048 bytes in 4 blocks
==2348==    indirectly lost: 0 bytes in 0 blocks
==2348==      possibly lost: 0 bytes in 0 blocks