### PR TITLE
Fix locking issue in insert mode

### DIFF
--- a/src/bric.c
+++ b/src/bric.c
@@ -1743,11 +1743,11 @@ void editor_process_key_press(int fd)
                         case CTRL_Q:
                                 //quit if the file isnt dirty
                                 if(Editor.dirty && quit_times) {
-                                        editor_set_status_message("WARNING! File has unsaved changes." "Press Ctrl-Q %d more times to quit.", quit_times);
+                                        editor_set_status_message("WARNING! File has unsaved changes. " "Press Ctrl-Q %d more times to quit.", quit_times);
                                         quit_times--;
                                         return;
                                 }
-                                exit(0);
+                                editor_harsh_quit();
                                 break;
                         case CTRL_S:
                                 editor_save();


### PR DESCRIPTION
Very small fix to #111 , lock will now be deleted when exiting in insert mode. Might want to consider replacing `exit()` with `editor_harsh_quit()` in other places as well.