### PR TITLE
README.md:add build and install instructions [skip ci](closes #122)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.com/shnupta/bric.svg?branch=development)](https://travis-ci.com/shnupta/bric)
 
-[![Waffle.io - Columns and their card count](https://badge.waffle.io/shnupta/bric.svg?columns=all)](https://waffle.io/shnupta/bric) 
+[![Waffle.io - Columns and their card count](https://badge.waffle.io/shnupta/bric.svg?columns=all)](https://waffle.io/shnupta/bric)
 
 [Join our slack team!](https://bric-editor.slack.com)
 
@@ -14,12 +14,42 @@ bric does not depend on any library (not even curses). It uses fairly standard V
 ### Here is a screencast of bric on macOS:
 ![Screencast](https://github.com/shnupta/bric/blob/master/screencast_low.gif)
 
-### Installation:
-```
-git clone https://github.com/shnupta/bric
-cd bric
-make install
-```
+### Getting the code
+
+The links to the git repo or source archives can be found at
+https://github.com/shnupta/bric
+
+### Building and Installation:
+
+    From the top level of the source directory, run:
+
+    ./configure (use `./configure --help` to set extra options)
+
+By default, `make install' will install all the files in
+`/usr/local/bin', `/usr/local/lib' etc.  You can specify
+an installation prefix other than `/usr/local' using `./configure --prefix',
+for instance `--prefix=$HOME' or `--prefix=$PWD/install_test`.
+
+    make (Before install, the resulting `bric` binary will be located in src/)
+
+If you have write privileges to *prefix*:
+
+    make install (otherwise, use `sudo make install`)
+
+*Note:* You will never need root privileges to `make` bric, and it's
+good practice only to use super-user privileges when absolutely required.
+
+Those instructions will be adequate for most users, but more details
+can be found in the [INSTALL](INSTALL) document.
+
+#### Removing files:
+
+    make clean
+    make distclean
+
+#### Uninstalling
+
+    make uninstall (must be run before `make distclean`)
 
 ### Usage:
 If you have performed a `make install` then just `bric <filename>`. It can be a new or existing filename.


### PR DESCRIPTION
These instructions are for using `configure` and `make`, which have
recently become available xD