### PR TITLE
Add syntax support for Haxe

### DIFF
--- a/src/modules/syntax/haxe/haxe.h
+++ b/src/modules/syntax/haxe/haxe.h
@@ -8,6 +8,7 @@ char *HAXE_keywords[] = {
 	"Bool", "Float", "Int", "true", "false", "String",
 	"null", "Void", "NaN", "Array",
 	"var", "trace", "Node", "TString", "TInt", "Class",
+	"EReg",
 
 	//conditionals
 	"switch~", "if~", "throw~", "else~", "case~", "try~", "catch~",
@@ -19,11 +20,12 @@ char *HAXE_keywords[] = {
 	//adapters
 	"static^", "public^", "protected^", "private^", "class^", "extern^",
 	"function^", "import^", "using^", "typedef^", "inline^", "package^",
+	"cast^", "implements^",
 
 	//loops
 	"for@", "while@", "do@", "in@", "...@",
 
-	// Should figure out metadata lixe @:keep and @:rtti selectors in haxe.
+	// Should figure out metadata like @:keep and @:rtti selectors in haxe.
 	// https://haxe.org/manual/lf-metadata.html
 
 	NULL

--- a/src/modules/syntax/haxe/haxe.h
+++ b/src/modules/syntax/haxe/haxe.h
@@ -1,0 +1,41 @@
+#ifndef _SYNTAX_HAXE_H
+#define _SYNTAX_HAXE_H
+
+// HAXE
+char *HAXE_extensions[] = {".hx",NULL};
+char *HAXE_keywords[] = {
+	//types and misc
+	"Bool", "Float", "Int", "true", "false", "String",
+	"null", "Void", "NaN", "Array",
+	"var", "trace", "Node", "TString", "TInt", "Class",
+
+	//conditionals
+	"switch~", "if~", "throw~", "else~", "case~", "try~", "catch~",
+	"Type~",
+
+	//return
+	"return#", "break#","continue#",
+
+	//adapters
+	"static^", "public^", "protected^", "private^", "class^", "extern^",
+	"function^", "import^", "using^", "typedef^", "inline^", "package^",
+
+	//loops
+	"for@", "while@", "do@", "in@", "...@",
+
+	// Should figure out metadata lixe @:keep and @:rtti selectors in haxe.
+	// https://haxe.org/manual/lf-metadata.html
+
+	NULL
+};
+
+#define HAXE_syntax { \
+	HAXE_extensions, \
+	HAXE_keywords, \
+	"//", \
+	"/*", \
+	"*/", \
+	HL_HIGHLIGHT_NUMBERS | HL_HIGHLIGHT_STRINGS \
+}
+
+#endif

--- a/src/modules/syntax/syntax.h
+++ b/src/modules/syntax/syntax.h
@@ -20,6 +20,7 @@
 #include "makefile/makefile.h"
 #include "dockerfile/dockerfile.h"
 #include "swift/swift.h"
+#include "haxe/haxe.h"
 
 // Syntax highlighting macros
 #define HL_NORMAL 0
@@ -64,7 +65,8 @@ struct editor_syntax highlight_db[] = {
   BASH_syntax,
   MAKEFILE_syntax,
   DOCKERFILE_syntax,
-  SWIFT_syntax
+  SWIFT_syntax,
+  HAXE_syntax
 };
 
 #define HIGHLIGHT_DB_ENTRIES (sizeof(highlight_db)/sizeof(highlight_db[0]))


### PR DESCRIPTION
Haxe is a language that is somewhat alike to ecmascript based languages, it's both runnable in virtual machines and transpilable to different languages.

Such a versatile language deserves this highlighting. And so I did.

\o/